### PR TITLE
consolidate new + scaffold command into one

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,16 +27,17 @@ program
   .version('0.7.3');
 
 program
-  .command('new')
-  .option('-t, --title <title>', 'Title of new project')
-  .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. Default: development')
-  .option('-r, --protocol <protocol>', 'protocol of running BITBOX instance. Default: http')
-  .option('-o, --host <host>', 'host of running BITBOX instance. Default: localhost')
-  .option('-p, --port <port>', 'port of running BITBOX instance. Default: 8332')
+  .command('new <name>')
+  .option('-s, --scaffold <scaffold>', 'The framework to use. Options include react, angular, nextjs and node. (Default: react)')
+  .option('-r, --scaffold-repo <repo>', 'The github repository to use. Ex: https://github.com/bigearth/bitbox-scaffold-react.git')
+  .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. (Default: development)')
+  .option('-r, --protocol <protocol>', 'protocol of running BITBOX instance. (Default: http)')
+  .option('-o, --host <host>', 'host of running BITBOX instance. (Default: localhost)')
+  .option('-p, --port <port>', 'port of running BITBOX instance. (Default: 8332)')
   .option('-u, --username <username>', 'Bitcoin Cash JSON RPC username')
   .option('-a, --password <passwore>', 'Bitcoin Cash JSON RPC password')
   .description(`create a new BITBOX application`)
-  .action((options) => {
+  .action((name, options) => {
     clear();
     console.log(
       chalk.blue(
@@ -49,104 +50,101 @@ program
     fs.readFile(os.homedir() + '/.bitboxrc', 'utf8', (err, contents) => {
       let config;
       if(contents) {
-        // if ~/.bitboxrc exists read values from it
         config = ini.parse(contents);
       }
 
       let environment;
-      // set environment
       if(options && options.environment) {
-        // first check incoming flags
         environment = options.environment;
       } else if(config && config.new && config.new.environment) {
-        // next check ~/.bitboxrc
         environment = config.new.environment;
       } else {
-        // finally hardcode to development
         environment = 'development';
       }
 
       let protocol;
-      // set protocol
       if(options && options.protocol) {
-        // first check incoming flags
         protocol = options.protocol;
       } else if(config && config.new && config.new.protocol) {
-        // next check ~/.bitboxrc
         protocol = config.new.protocol;
       } else {
-        // finally hardcode to http
         protocol = 'http';
       }
 
       let host;
       if(options && options.host) {
-        // first check incoming flags
         host = options.host;
       } else if(config && config.new && config.new.host) {
-        // next check ~/.bitboxrc
         host = config.new.host;
       } else {
-        // finally hardcode to localhost
         host = 'localhost';
       }
 
       let port;
       if(options && options.port) {
-        // first check incoming flags
         port = options.port;
       } else if(config && config.new && config.new.port) {
-        // next check ~/.bitboxrc
         port = config.new.port;
       } else {
-        // finally hardcode to 8332
         port = 8332;
       }
 
       let username;
       if(options && options.username) {
-        // first check incoming flags
         username = options.username;
       } else if(config && config.new && config.new.username) {
-        // next check ~/.bitboxrc
         username = config.new.username;
       } else {
-        // finally hardcode to empty string
         username = '';
       }
 
       let password;
       if(options && options.password) {
-        // first check incoming flags
         password = options.password;
       } else if(config && config.new && config.new.password) {
-        // next check ~/.bitboxrc
         password = config.new.password;
       } else {
-        // finally hardcode to empty string
         password = '';
       }
 
-      // check flags for title
-      let title = options.title;
-      if(!title) {
-        // hardcode to BITBOX
-        console.log(chalk.bold.red("You didn't provide a title! Using BITBOX instead. #SorryNotSorry"));
-        title = 'BITBOX';
+      if(options && options.scaffold) {
+        let scaffold = options.scaffold.toLowerCase();
+        let repo;
+        let conf = {};
+        if(scaffold === 'node') {
+          repo = 'https://github.com/bigearth/bitbox-scaffold-node.git';
+        } else if(scaffold === 'angular') {
+          repo = 'https://github.com/bigearth/bitbox-scaffold-angular.git';
+        } else if(scaffold === 'nextjs') {
+          repo = 'https://github.com/bigearth/bitbox-scaffold-nextjs.git';
+        } else if(scaffold === 'react') {
+          repo = 'https://github.com/bigearth/bitbox-scaffold-react.git';
+        }
+
+        if(options && options.repo) {
+          scaffold = 'custom repo';
+          repo = options.repo.toLowerCase();
+        }
+        console.log(chalk.blue(`Scaffolding ${scaffold} app in ${name}`));
+        clone(repo, `./${name}`, [conf], () => {
+          console.log(chalk.green('All done.'), emoji.get(':white_check_mark:'));
+          console.log(chalk.blue('Now confirm you have your locally running BITBOX and run `npm install && npm start`'), emoji.get(':rocket:'));
+        });
+        return;
       }
 
-      console.log(chalk.green(`Creating ${title}/ directory`));
-      console.log(chalk.green(`Creating src/ directory: ./${title}/src`));
-      mkdirp(`./${title}/src`, (err) => {});
+      console.log(chalk.green(`Creating ${name}/ directory`));
+      console.log(chalk.green(`Creating src/ directory: ./${name}/src`));
+      mkdirp(`./${name}/src`, (err) => {});
 
-      console.log(chalk.green(`Creating tests/ directory: ./${title}/tests`));
-      mkdirp(`./${title}/tests`, (err) => {});
+      console.log(chalk.green(`Creating tests/ directory: ./${name}/tests`));
+      mkdirp(`./${name}/tests`, (err) => {});
 
       console.log(chalk.green(`Creating bitbox.js configuration file`));
 
-      mkdirp(`./${title}`, (err) => {});
-      touch(`./${title}/bitbox.js`);
-      fs.writeFileSync( `./${title}/bitbox.js`, `exports.config = {
+      mkdirp(`./${name}`, (err) => {});
+      touch(`./${name}/bitbox.js`);
+      fs.writeFileSync( `./${name}/bitbox.js`, `exports.config = {
   networks: {
     ${environment}: {
       protocol: "${protocol}",
@@ -158,6 +156,7 @@ program
   }
 };
 `);
+
     console.log(chalk.blue('All done.'), emoji.get(':white_check_mark:'));
     console.log(chalk.blue('Go get em! Remember--with great power comes great responsibility.'), emoji.get(':rocket:'));
     });
@@ -166,7 +165,7 @@ program
 
 program
   .command('console')
-  .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. Default: development')
+  .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. (Default: development)')
   .description('Run a console with Bitcoin Cash RPC commands available')
   .action((options) => {
     let config = require(process.cwd() + '/bitbox.js').config;
@@ -174,20 +173,15 @@ program
     fs.readFile(os.homedir() + '/.bitboxrc', 'utf8', (err, contents) => {
       let conf;
       if(contents) {
-        // if ~/.bitboxrc exists read values from it
         conf = ini.parse(contents);
       }
 
       let environment;
-      // set environment
       if(options && options.environment) {
-        // first check incoming flags
         environment = options.environment;
       } else if(conf && conf.new && conf.new.environment) {
-        // next check ~/.bitboxrc
         environment = conf.new.environment;
       } else {
-        // finally hardcode to development
         environment = 'development';
       }
 
@@ -197,48 +191,9 @@ program
 );
 
 program
-  .command('scaffold')
-  .option('-f, --framework <framework>', 'The framework to use. Options include "react", "angular", "nextjs" and "node". Default: "react"')
-  .option('-r, --repo <repo>', 'The github repository to use. Ex: https://github.com/bigearth/bitbox-scaffold-react.git')
-  .description('Scaffold out basic apps in major frameworks w/ BITBOX bindings')
-  .action((options) => {
-    let framework;
-    if(options && options.framework) {
-      framework = options.framework.toLowerCase();
-    } else {
-      framework = 'react';
-    }
-
-    let repo;
-    let targetPath = './';
-    let conf = {};
-    if(framework === 'node') {
-      repo = 'https://github.com/bigearth/bitbox-scaffold-node.git';
-    } else if(framework === 'angular') {
-      repo = 'https://github.com/bigearth/bitbox-scaffold-angular.git';
-    } else if(framework === 'nextjs') {
-      repo = 'https://github.com/bigearth/bitbox-scaffold-nextjs.git';
-    } else {
-      repo = 'https://github.com/bigearth/bitbox-scaffold-react.git';
-    }
-
-    if(options && options.repo) {
-      framework = 'custom repo';
-      repo = options.repo.toLowerCase();
-    }
-
-    console.log(chalk.blue(`Scaffolding ${framework} app in current directory`));
-    clone(repo, targetPath, [conf], () => {
-      console.log(chalk.green('All done.'), emoji.get(':white_check_mark:'));
-      console.log(chalk.blue('Now confirm you have your locally running BITBOX and run `npm install && npm start`'), emoji.get(':rocket:'));
-    })
-  }
-);
-
-program
   .command('paper')
-  .option('-e, --encoding <encoding>', 'The encoding to use. Options include "cashaddr" and "legacy". Default: "cashaddr"')
-  .option('-l, --language <language>', 'language of mnemonic. Options: chinese_simplified, chinese_traditional, english, french, italian, japanese, korean, spanish. Default: english')
+  .option('-e, --encoding <encoding>', 'The encoding to use. Options include "cashaddr" and "legacy". (Default: "cashaddr")')
+  .option('-l, --language <language>', 'language of mnemonic. Options: chinese_simplified, chinese_traditional, english, french, italian, japanese, korean, spanish. (Default: english)')
   .description('Create a paper wallet for easy and safe back up')
   .action((options) => {
     if(!options.encoding || (options.encoding !== 'cashaddr' && options.encoding !== 'legacy')) {
@@ -283,7 +238,6 @@ program
         `);
       })
     })
-
   }
 );
 
@@ -299,7 +253,6 @@ program
       // console.log('')
     }
     );
-
   }
 );
 


### PR DESCRIPTION
* instead of `bitxbox new --title foo` now `bitbox new foo` (raise error if no name is given instead of default name) NOTE: exact same behavior as before

* roll scaffold into `new` command as `--scaffold` flag, scaffold `--repo` flag is now `--scaffold-repo`

```
  Usage: new [options] <name>

  create a new BITBOX application

  Options:

    -s, --scaffold <scaffold>        The framework to use. Options include react, angular, nextjs and node. (Default: react)
    -r, --scaffold-repo <repo>       The github repository to use. Ex: https://github.com/bigearth/bitbox-scaffold-react.git
    -e, --environment <environment>  environment of running BITBOX instance. Ex: production, staging. (Default: development)
    -r, --protocol <protocol>        protocol of running BITBOX instance. (Default: http)
    -o, --host <host>                host of running BITBOX instance. (Default: localhost)
    -p, --port <port>                port of running BITBOX instance. (Default: 8332)
    -u, --username <username>        Bitcoin Cash JSON RPC username
    -a, --password <passwore>        Bitcoin Cash JSON RPC password
    -h, --help                       output usage information
```