### PR TITLE
Persistent console history (per-project)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 require("babel-register");
+let path = require('path');
 let program = require('commander');
 let chalk = require('chalk');
 let mkdirp = require('mkdirp');
@@ -169,9 +170,9 @@ program
   }
 };
 `);
-
-    console.log(chalk.blue('All done.'), emoji.get(':white_check_mark:'));
-    console.log(chalk.blue('Go get em! Remember--with great power comes great responsibility.'), emoji.get(':rocket:'));
+      fs.appendFileSync( `./${name}/.gitignore`, '.console_history');
+      console.log(chalk.blue('All done.'), emoji.get(':white_check_mark:'));
+      console.log(chalk.blue('Go get em! Remember--with great power comes great responsibility.'), emoji.get(':rocket:'));
     });
   }
 );
@@ -182,7 +183,10 @@ program
   .description('Run a console with Bitcoin Cash RPC commands available')
   .action((options) => {
     let config = require(process.cwd() + '/bitbox.js').config;
-    var replServer = repl.start('> ');
+    let replServer = repl.start('> ');
+    let historyFile = path.join(process.cwd(), '.console_history');
+    require('repl.history')(replServer, historyFile);
+
     fs.readFile(os.homedir() + '/.bitboxrc', 'utf8', (err, contents) => {
       let conf;
       if(contents) {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ program
 
 program
   .command('new <name>')
-  .option('-s, --scaffold <scaffold>', 'The framework to use. Options include react, angular, vuejs, nextjs and node. (Default: react)')
+  .option('-s, --scaffold <scaffold>', 'The framework to use. Options include react, angular, vuejs, nextjs and node.')
   .option('-r, --scaffold-repo <repo>', 'The github repository to use. Ex: https://github.com/bigearth/bitbox-scaffold-react.git')
   .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. (Default: development)')
   .option('-r, --protocol <protocol>', 'protocol of running BITBOX instance. (Default: http)')

--- a/index.js
+++ b/index.js
@@ -182,7 +182,12 @@ program
   .option('-e, --environment <environment>', 'environment of running BITBOX instance. Ex: production, staging. (Default: development)')
   .description('Run a console with Bitcoin Cash RPC commands available')
   .action((options) => {
-    let config = require(process.cwd() + '/bitbox.js').config;
+    try {
+      let config = require(process.cwd() + '/bitbox.js').config;
+    } catch(err) {
+      console.log(chalk.red('Console command must be run inside a bitbox project'));
+      process.exit(1);
+    }
     let replServer = repl.start('> ');
     let historyFile = path.join(process.cwd(), '.console_history');
     require('repl.history')(replServer, historyFile);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node-emoji": "^1.8.1",
     "qrcode": "^1.2.0",
     "randombytes": "^2.0.6",
+    "repl.history": "^0.1.4",
     "safe-buffer": "^5.1.2",
     "satoshi-bitcoin": "^1.0.4",
     "touch": "^3.1.0"


### PR DESCRIPTION
* Each project retains console history across different `bitbox-cli console` sessions
* `bitbox-cli new` now writes a `.gitignore` w/ `.console_history` added (could be really bad if someone accidentally committed their console history to git)
* couple small cleanup/ux improvements